### PR TITLE
Fix: Move {% extends %} to top of index.html

### DIFF
--- a/House_Renting_Platform/templates/index.html
+++ b/House_Renting_Platform/templates/index.html
@@ -1,4 +1,8 @@
-{% load static %}
+{% extends 'base.html'%}
+{% load static%}
+
+{%block content%}
+
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US" lang="en-US">
@@ -41,10 +45,6 @@
         </div>
     </div>
     <!-- /preload -->
-{% extends 'base.html'%}
-{% load static%}
-
-{%block content%}
 
 
     <div id="wrapper">


### PR DESCRIPTION
Fixes a template inheritance error where {% extends 'base.html' %} was not placed at the top of index.html, which was causing the page to fail rendering properly.